### PR TITLE
ALSA: hda/hdmi: Fix "Unknown ELD version 0" warnings

### DIFF
--- a/sound/pci/hda/patch_hdmi.c
+++ b/sound/pci/hda/patch_hdmi.c
@@ -1650,11 +1650,6 @@ static void hdmi_present_sense_via_verbs(struct hdmi_spec_per_pin *per_pin,
 		if (spec->ops.pin_get_eld(codec, pin_nid, dev_id,
 					  eld->eld_buffer, &eld->eld_size) < 0)
 			eld->eld_valid = false;
-
-		if (snd_hdmi_parse_eld(codec, &eld->info, eld->eld_buffer,
-						    eld->eld_size) < 0)
-			eld->eld_valid = false;
-
 	}
 
 	update_eld(codec, per_pin, eld, repoll);


### PR DESCRIPTION
Caused by Nvidia downstream commit 113aa1168dbd.

Also reported to them, but I guess this will be faster...