### PR TITLE
nvidia: dts: fix interrupts declaration for GICv3

### DIFF
--- a/nvidia/soc/t23x/kernel-dts/tegra234-soc/tegra234-soc-minimal.dtsi
+++ b/nvidia/soc/t23x/kernel-dts/tegra234-soc/tegra234-soc-minimal.dtsi
@@ -43,6 +43,9 @@
 		reg = <0x0 0x0f400000 0x0 0x00010000    /* GICD */
 		       0x0 0x0f440000 0x0 0x00200000>;  /* GICR CPU 0-15 */
 		ranges;
+		interrupts = <GIC_PPI 9
+			(GIC_CPU_MASK_SIMPLE(8) | IRQ_TYPE_LEVEL_HIGH)>;
+		interrupt-parent = <&intc>;
 		status = "disabled";
 
 		gic_v2m: v2m@f410000 {


### PR DESCRIPTION
I discovered there is a problem with running all hypervisors on NVIDIA Orin that're trying to utilize the GICv3 featured.
This includes qemu with GICv3 enabled and all RustVMM-based hypervisors -- they fail with "failed to create IRQ chip: No such device (os error 19)" diagnostics. 
Investigation discovered that nessessary control structures for GICv3 are not created during kernel device initialization in the kvm subsystem. That leads to bug in the DTS -- uncomplete interrupts declatation in interrupt-controller section. 
Fixed by adding the nesessary declarations

Signed-off-by: vadik likholetov <vadim.likholetov@unikie.com>