### PR TITLE
soc: tegra: Remove warning when not running on Tegra SoC

### DIFF
--- a/drivers/soc/tegra/fuse/tegra-apbmisc.c
+++ b/drivers/soc/tegra/fuse/tegra-apbmisc.c
@@ -72,7 +72,9 @@ static u32 chipid;
 
 u32 tegra_read_chipid(void)
 {
-	WARN(!chipid, "Tegra APB MISC not yet available\n");
+	/** Warning only when running on a Tegra SoC */
+	if (soc_is_tegra())
+		WARN(!chipid, "Tegra APB MISC not yet available\n");
 
 	return chipid;
 }


### PR DESCRIPTION
When using the same kernel from a Jetson Xavier platform on a VM with QEMU, the following warning is being issued:

[    0.007891] Tegra APB MISC not yet available
[    0.007935] WARNING: CPU: 0 PID: 1 at drivers/soc/tegra/fuse/tegra-apbmisc.c:75 tegra_read_chipid+0x3c/0x50
[    0.007952] Modules linked in:
[    0.007967] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 5.10.104-linuxkit #48
[    0.007980] pstate: 60400005 (nZCv daif +PAN -UAO -TCO BTYPE=--)
[    0.007990] pc : tegra_read_chipid+0x3c/0x50
[    0.007999] lr : tegra_read_chipid+0x3c/0x50
[    0.008007] sp : ffff800010013d60
[    0.008015] x29: ffff800010013d60 x28: 0000000000000000
[    0.008047] x27: 0000000000000000 x26: 0000000000000000
[    0.008062] x25: 0000000000000000 x24: 0000000000000000
[    0.008092] x23: 0000000000000000 x22: 0000000000000000
[    0.008120] x21: 0000000000000000 x20: ffff800011cb8b00
[    0.008135] x19: ffff8000124eea70 x18: ffffffffffffffff
[    0.008150] x17: 00000000000000c0 x16: fffffdffffe05000
[    0.008164] x15: ffff800011ac8a38 x14: 0720072007200720
[    0.008179] x13: 0720072007200720 x12: 0720072007200720
[    0.008193] x11: 0720072007200720 x10: 0720072007200720
[    0.008207] x9 : 0720072007200720 x8 : 0720072007200720
[    0.008222] x7 : ffff800012178378 x6 : c0000000ffffefff
[    0.008236] x5 : ffff800012178320 x4 : 0000000000000000
[    0.008251] x3 : 0000000000000000 x2 : ffff80001035dc60
[    0.008265] x1 : a4f500439318b400 x0 : 0000000000000000
[    0.008280] Call trace:
[    0.008290]  tegra_read_chipid+0x3c/0x50
[    0.008299]  tegra_get_chip_id+0x14/0x20
[    0.008333]  tegra18x_mce_early_init+0x14/0x38
[    0.008344]  do_one_initcall+0x54/0x2a0
[    0.008369]  kernel_init_freeable+0x1a0/0x35c
[    0.008380]  kernel_init+0x18/0x120
[    0.008389]  ret_from_fork+0x10/0x18
[    0.008414] ---[ end trace 0d186c088434c480 ]---

This commit adds a check to issue the warning only when running on a Tegra SoC.